### PR TITLE
도메인 레코드 설정 가이드 link update

### DIFF
--- a/docs/marketing/marketing.mdx
+++ b/docs/marketing/marketing.mdx
@@ -33,7 +33,7 @@ Relate 캠페인의 가장 큰 우선순위는 이메일 전달률(Email Deliver
 ## How it works
 
 <Note>
-    캠페인을 사용하기 위해서는 우선 발신용 도메인을 등록해야 합니다. 발신 도메인 등록 절차는 [도메인 레코드 설정 가이드](/docs/marketing/dns-records)를 참고해주세요.
+    캠페인을 사용하기 위해서는 우선 발신용 도메인을 등록해야 합니다. 발신 도메인 등록 절차는 [도메인 레코드 설정 가이드](/marketing/dns-records)를 참고해주세요.
 </Note>
 
 


### PR DESCRIPTION
캠페인(Campaigns) 페이지에서 도메인 레코드 설정 가이드로 이동할 수 있도록 걸어둔 link가 잘못되어 있어 변경했습니다.
사진 속 '**도메인 레코드 설정 가이드**' 부분
![CleanShot 2024-10-29 at 15 05 20@2x](https://github.com/user-attachments/assets/db433cc3-ee73-47f8-ac94-0db52411a458)
