### PR TITLE
Fix unnecessary double quotation for Processes Page

### DIFF
--- a/docs/features/processes.mdx
+++ b/docs/features/processes.mdx
@@ -16,7 +16,7 @@ sidebarTitle: "프로세스 (Processes)"
 
 업무 흐름상 Organization 또는 Contact의 상태를 관리해야 할 때 주로 사용할 수 있습니다. 예를 들면, 영업 파이프라인의 경우 여러 영업 기회(Opportunity)들을 한 프로세스에서 관리할 수 있습니다.
 
-각 ["엔트리(Entry)""](/features/processes#1-entry)는 연결된 Organization/Contact에 대한 영업 기회를 나타냅니다.
+각 ["엔트리(Entry)"](/features/processes#1-entry)는 연결된 Organization/Contact에 대한 영업 기회를 나타냅니다.
 
 한번만 영업하는 것이 아니므로, 한 Organization/Contact은 여러 개의 엔트리를 보유할 수 있습니다.
 


### PR DESCRIPTION
[프로세스 설명 페이지](https://www.relate.kr/docs/features/processes)의 엔트리를 둘러싼 중복된 큰따옴표를 제거합니다.
![image](https://github.com/user-attachments/assets/d6139b8a-b3cd-4210-8358-6a0ce118040b)