### PR TITLE
API 레퍼런스 연락처 문서에 핸드폰 번호 검색 추가

### DIFF
--- a/docs/api/contacts.mdx
+++ b/docs/api/contacts.mdx
@@ -35,6 +35,14 @@ curl -X GET "https://api.relate.so/v1/contacts?email=email@email.com" \
   -H "Accept: application/json"
 ```
 
+핸드폰 번호로도 찾을 수 있습니다. 입력한 번호는 저장 시점과 동일하게 정규화되므로, `+821012345678`, `01012345678`, `010-1234-5678` 등 어떤 형식으로 보내도 같은 연락처에 매칭됩니다.
+
+```bash
+curl -X GET "https://api.relate.so/v1/contacts?phone_number=01012345678" \
+  -H "Authorization: Bearer {api_key}" \
+  -H "Accept: application/json"
+```
+
 ## 연락처 생성
 
 ```bash


### PR DESCRIPTION
공개 API 컨택 검색(`GET /v1/contacts`)에 핸드폰 번호 검색(`?phone_number=`)이 추가되어(relate-server #4206, DEV-7203), 기존 이메일 검색과 대칭으로 문서화한다. 입력 번호가 저장 시점과 동일하게 정규화되므로 `+8210.../010-.../01012345678` 등 형식 무관하게 같은 연락처에 매칭된다는 점을 함께 안내한다.

2026-06-29 운영 배포본에서 KR/US 형식 무관 매칭 + 엣지 케이스 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)